### PR TITLE
🎨 [FE] 명예의전당 페이지 마크업

### DIFF
--- a/app/(public)/about/honor/page.js
+++ b/app/(public)/about/honor/page.js
@@ -1,0 +1,10 @@
+import Intro from '@/components/service/Intro';
+export default function HonorPage() {
+  return (
+    <section className="mx-auto flex w-full flex-col gap-8">
+      <div className="space-y-2">
+        <Intro />
+      </div>
+    </section>
+  );
+}

--- a/components/service/honor/Honor.jsx
+++ b/components/service/honor/Honor.jsx
@@ -1,0 +1,72 @@
+import HonorGrid from "./HonorGrid";
+
+export default function Honor() {
+  // 샘플 데이터 
+  const donors = [
+    {
+      amount: 2000000,
+      name: "박건희",
+      org: "필사그래피",
+      dept: "컴퓨터공학과",
+      message: "필사 화이팅",
+    },
+    { amount: 1000000, name: "윤정민", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 500000, name: "하종연", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 300000, name: "신채원", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 200000, name: "정주환", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 100000, name: "문예빈", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 50000, name: "김효림", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 10000, name: "정도이", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 10000, name: "한서은", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 5000, name: "김수현", org: "필사그래피", dept: "컴퓨터공학과" },
+    { amount: 5000, name: "이연서", org: "필사그래피", dept: "컴퓨터공학과" },
+  ];
+  
+  const sortedDonors = [...donors].sort((a, b) => b.amount - a.amount);
+
+  const totalCount = sortedDonors.length;
+
+  const firstRanker = sortedDonors.slice(0, 1);
+  const topRankers = sortedDonors.slice(1, 4);
+  const normalRankers = sortedDonors.slice(4);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1016px] flex-col gap-[30px] bg-white p-8">
+      {/* 타이틀 영역 */}
+      <header className="flex flex-col gap-[12px] pb-[40px] border-b-[1.5px]">
+        <h2 className="font-['Pretendard',sans-serif] font-semibold text-[24px] leading-[1.5] tracking-[-0.48px] text-[#212121]">
+          명예의 전당
+        </h2>
+        <p className="font-['Pretendard',sans-serif] font-normal text-[16px] leading-[1.6] tracking-[-0.32px] text-[#919191]">
+          필사그래피 명예의 전당
+        </p>
+      </header>
+
+      {/* 등수별 그리드 영역 */}
+      <section className="flex flex-col">
+        {/* 1등 (데이터가 1개 이상일 경우 표시) */}
+        {totalCount >= 1 && (
+          <HonorGrid title="" items={firstRanker} rankType="first" />
+        )}
+
+        {/* 2-4등 (데이터가 2개 이상일 경우 표시) */}
+        {totalCount >= 2 && (
+          <HonorGrid
+            title={totalCount === 2 ? "2등" : `2-${Math.min(totalCount, 4)}등`}
+            items={topRankers}
+            rankType="top"
+          />
+        )}
+
+        {/* 5~n등 (데이터가 5개 이상일 경우 표시) */}
+        {totalCount >= 5 && (
+          <HonorGrid
+            title={totalCount === 5 ? "5등" : `5-${totalCount}등`}
+            items={normalRankers}
+            rankType="normal"
+          />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/service/honor/HonorCard.jsx
+++ b/components/service/honor/HonorCard.jsx
@@ -1,0 +1,61 @@
+const HonorCard = ({ data, rankType }) => {
+  const props = {
+    first: {
+      w: "w-full max-w-[240px]",
+      aspect: "aspect-[3/4]",
+      gap: "gap-5",
+      info: "text-[18px] font-semibold leading-[32px]",
+    },
+    top: {
+      w: "w-full max-w-[180px]",
+      aspect: "aspect-[3/4]",
+      gap: "gap-4",
+      info: "text-[16px] font-semibold",
+    },
+    normal: {
+      w: "w-full max-w-[129px]",
+      aspect: "aspect-[3/4]",
+      gap: "gap-3",
+      info: "text-[12px]",
+    },
+  };
+
+  const style = props[rankType];
+
+  return (
+    <div className={`flex flex-col items-center ${style.w} ${style.gap}`}>
+      {/* 이미지 영역 */}
+      <div className={`w-full bg-gray-200 overflow-hidden ${style.aspect}`}>
+        {data.imageUrl && (
+          <Image
+            src={data.imageUrl}
+            alt={data.name}
+            className="w-full h-full object-cover"
+          />
+        )}
+      </div>
+
+      {/* 인포 영역 */}
+      <div className={`text-center ${style.info}`}>
+        {rankType === "first" ? (
+          <>
+            {/* 1등 (first) */}
+            <p>{data.name}</p>
+            <p>{data.org}</p>
+            <p>{data.dept}</p>
+            <p>" {data.message} "</p>
+          </>
+        ) : (
+          <>
+            {/* 2등 ~ n등 (top, normal) */}
+            <p className="font-semibold">{data.name}</p>
+            <p>{data.org}</p>
+            <p>{data.dept}</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HonorCard;

--- a/components/service/honor/HonorGrid.jsx
+++ b/components/service/honor/HonorGrid.jsx
@@ -1,0 +1,29 @@
+import HonorCard from "./HonorCard";
+
+const HonorGrid = ({ title, items, rankType }) => {
+  const props = {
+    first: "flex justify-center",
+    top: "grid grid-cols-3 gap-x-4 justify-items-center",
+    normal:
+      "grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-x-2 gap-y-12 justify-items-center",
+  };
+
+  return (
+    <section className="flex flex-col gap-8 mb-20">
+      <h3 className="text-[24px] font-semibold leading-[1.5] tracking-[-0.02] text-[#757575]">
+        {title}
+      </h3>
+      <div className={props[rankType]}>
+        {items.map((item) => (
+          <HonorCard
+            key={`${item.name}-${item.dept}`}
+            data={item}
+            rankType={rankType}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default HonorGrid;


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 🎨 [FE] 명예의전당 페이지 마크업

## What has changed? 🤔

- (public)/about/honor/page.js
- components/service/honor/Honor
- components/service/honor/HonorCard
- components/service/honor/HonorGrid


## Whether needed review 🖍

<!-- 마크다운의 빈 체크박스 문법은 [ ] / 채워진 체크박스 문법은 [x] 입니다. -->

- [x] 🙋🏻 리뷰가 필요합니다!
- [ ] 🙅🏻 리뷰가 필요하지 않습니다!


## Document🗒️ (Optional)
5등 이하 영역은 화면 크기에 따라 컬럼 수가 최소 3개에서 최대 5개까지 반응형으로 변경되도록 구현하였습니다. 


## Screenshot 📸 (Optional)
(1) 기본 
<img width="2811" height="1434" alt="image" src="https://github.com/user-attachments/assets/2ddc3de9-0ec9-41ec-b959-e12ed6e1ad37" />
<img width="2817" height="1436" alt="image" src="https://github.com/user-attachments/assets/d02ee1a7-3120-4156-9f55-a82bf21bcadc" />
<img width="2803" height="1347" alt="image" src="https://github.com/user-attachments/assets/e3eed4bd-dc9c-4ea1-9260-cde0e147cb5b" />


(2) 데이터 개수에 따른 변화 
<img width="2806" height="1429" alt="image" src="https://github.com/user-attachments/assets/81ca4e94-bf26-4247-872f-6d00c4e2f6f2" />
<img width="2816" height="1430" alt="image" src="https://github.com/user-attachments/assets/4dc327f6-2ed6-46d5-a1a2-7c844b3501d0" />


(3) 화면 사이즈에 따른 col 수 변화 
<img width="934" height="1371" alt="image" src="https://github.com/user-attachments/assets/8af6f25e-bc09-44e2-a7ca-41de3806a86d" />
