### PR TITLE
🎨 [FE] 재학생 페이지 메인 대시보드 마크업(수정)

### DIFF
--- a/components/service/studentDashboard/StudentsDashboardGroup.jsx
+++ b/components/service/studentDashboard/StudentsDashboardGroup.jsx
@@ -6,6 +6,7 @@ import { DUMMY_POSTS_FREE } from '@/mocks/top4Data';
 import { ArrowRight } from 'lucide-react';
 import { getTop5Notices } from '@/apis/notice';
 import { getErrorMessage } from '@/apis/auth';
+import CategoryBadge from '@/components/shared/board/CategoryBadge';
 
 // 게시판 5개 노출
 function BoardList({
@@ -28,7 +29,7 @@ function BoardList({
   return (
     <div className="flex flex-col gap-[10px] w-full lg:w-[424.5px]">
       <div className="flex justify-between items-center pr-[20px] h-[30px] w-full">
-        <h3 className="mx-auto text-[20px] font-medium tracking-[-0.02em] leading-[1.5] text-black pl-[16px]">
+        <h3 className="text-[20px] font-medium tracking-[-0.02em] leading-[1.5] text-black">
           {title}
         </h3>
 
@@ -56,13 +57,10 @@ function BoardList({
               onClick={() => goDetail(post.postId)}
               className="flex items-center h-[56px] border-b border-[#B9B9B9] cursor-pointer hover:bg-[#F6F6F6] transition"
             >
+              {/* 번호/중요 뱃지 영역 */}
               <div className="w-[80px] flex justify-center items-center flex-shrink-0">
-                {boardType === 'notices' && post.isPinned ? (
-                  <div className="flex justify-center items-center px-[12px] py-[10px] w-[46px] h-[27px] bg-[#212121] rounded-[103px]">
-                    <span className="text-[12px] font-normal leading-[1.4] tracking-[-0.02em] text-white">
-                      중요
-                    </span>
-                  </div>
+                {boardType === 'notices' && Boolean(post.pinned ?? post.isPinned) ? (
+                  <CategoryBadge>중요</CategoryBadge>
                 ) : (
                   <span className="text-[16px] font-normal leading-[1.6] tracking-[-0.02em] text-[#454545]">
                     {index + 1}

--- a/components/service/studentDashboard/StudentsDashboardIntro.jsx
+++ b/components/service/studentDashboard/StudentsDashboardIntro.jsx
@@ -23,24 +23,28 @@ export default function StudentsDashboardIntro() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-[4px] w-full max-w-[915px]">
-      {/* 영역 1: 사용자 이름 인사 */}
-      <h1 className="text-[24px] font-medium tracking-[-0.02em] leading-[1.5] text-black h-[36px] flex items-center">
-        {userData.userName}님, 안녕하세요! :) ✍️
-      </h1>
+    // 1. 껍데기 제거: p-8, max-width, mx-auto를 지워서 부모의 정렬을 따르게 합니다.
+    <div className="flex w-full flex-col">
+      {/* 2. 상단 텍스트와 랜덤 메시지를 한 줄로 배치 (justify-between) */}
+      <div className="flex justify-between items-end w-full pb-[40px]">
+        {/* 왼쪽: 인사말 */}
+        <div className="flex flex-col gap-[12px]">
+          <h2 className="font-['Pretendard',sans-serif] font-semibold text-[24px] leading-[1.5] tracking-[-0.48px] text-[#212121]">
+            {userData.userName}님, 안녕하세요! :) ✍️
+          </h2>
+          <p className="font-['Pretendard',sans-serif] font-normal text-[18px] leading-[1.6] tracking-[-0.32px] text-[#212121]">
+            오늘도 좋은하루 보내세요 !
+          </p>
+        </div>
 
-      {/* 영역 2: 응원 및 랜덤 멘트 */}
-      <div className="flex flex-col gap-[4px] w-full">
-        {/* 행복한 하루 보내라는 응원멘트 */}
-        <p className="text-[18px] font-normal tracking-[-0.02em] leading-[1.6] text-[#212121] h-[36px] flex items-center">
-          오늘도 좋은하루 보내세요.
-        </p>
-
-        {/* 랜덤 응원 멘트 */}
-        <p className="text-[14px] font-normal tracking-[-0.02em] leading-[1.6] text-[#B9B9B9] text-right">
+        {/* 오른쪽: 랜덤 응원 멘트 (우측 정렬) */}
+        <p className="text-[14px] font-normal tracking-[-0.02em] text-[#B9B9B9] pb-[4px]">
           "{randomMessage}"
         </p>
       </div>
+
+      {/* 3. 구분선 (필요시 살리고, 필요 없으면 제거하세요) */}
+      <div className="w-full border-b-[1.5px] border-[#DEDEDE]" />
     </div>
   );
 }

--- a/components/service/studentDashboard/StudentsDashboardSection.jsx
+++ b/components/service/studentDashboard/StudentsDashboardSection.jsx
@@ -8,7 +8,7 @@ import { calendarMockResponse } from '@/mocks/calendarData';
 // 합치는 곳
 export default function StudentsDashboardSection() {
   return (
-    <section className="flex flex-col items-start p-0 gap-[40px] w-[915px]">
+    <section className="mx-auto flex w-full max-w-[1016px] flex-col bg-white p-8 gap-[51px]">
       {/* 영역 1: 인사말 */}
       <StudentsDashboardIntro />
 


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 🎨 [FE] 재학생 페이지 메인 대시보드 마크업(수정)

## What has changed? 🤔

- StudentsDashboardGroup.jsx

- StudentsDashboardIntro.jsx

- StudentsDashboardSection.jsx

## Whether needed review 🖍

<!-- 마크다운의 빈 체크박스 문법은 [ ] / 채워진 체크박스 문법은 [x] 입니다. -->

- [x] 🙋🏻 리뷰가 필요합니다!
- [ ] 🙅🏻 리뷰가 필요하지 않습니다!


## Document🗒️ (Optional)

다른 게시판과 레이아웃 맞추기 완료 및 화면구성 통일성을 위해 구분선 하나 추가했습니다. 
중요표시가 보이지 않는 문제 해결했습니다. 

## Screenshot 📸 (Optional)
![KakaoTalk_Photo_2026-03-16-21-27-20](https://github.com/user-attachments/assets/58bd8264-17df-4e03-8db4-84ae7169eff6)
![KakaoTalk_Photo_2026-03-16-21-27-27](https://github.com/user-attachments/assets/b3fb081e-1f50-4aa6-a9ac-29a8fe229a23)
화면구성 같은거 보실 수 있습니다 !
